### PR TITLE
feat: use persistent external bootstrap ips

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -22,6 +22,24 @@ spec:
         port: 9093
         type: internal
         tls: true
+      - name: external
+        port: 9094
+        type: loadbalancer
+        tls: false
+        configuration:
+          bootstrap:
+            annotations:
+              metallb.universe.tf/address-pool: sdf-services
+          brokers:
+            - broker: 0
+              annotations:
+                metallb.universe.tf/address-pool: sdf-services
+            - broker: 1
+              annotations:
+                metallb.universe.tf/address-pool: sdf-services
+            - broker: 2
+              annotations:
+                metallb.universe.tf/address-pool: sdf-services
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5


### PR DESCRIPTION
this enables external communication to the kakfa brokers with IPs on the sdf-services subnet. we may change this to a different 'ingress' subnet in the future.